### PR TITLE
Add TypeDoc documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
-.sass-cache
+docs/
 node_modules/
+.sass-cache
 *.sublime-workspace
 *~
 #*#

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ gulp.task("js", function () {
     return browserify({
 	    basedir: '.',
 	    debug: false,
-	    entries: ['src/js/controller.ts'],
+            entries: ['src/js/controller.ts'],
             cache: {},
             packageCache: {}
     })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,9 +7,20 @@ var sourcemaps = require("gulp-sourcemaps");
 var buffer = require("vinyl-buffer");
 var sass = require("gulp-sass");
 var tsc = require('gulp-typescript');
+var typedoc = require('gulp-typedoc');
 
 var tsServerProject = tsc.createProject('config/tsserver.json');
 
+gulp.task("docs", function () {
+    return gulp
+        .src(["src/**/*.ts", "!src/**/*.spec.ts"])
+        .pipe(typedoc({
+	    module: "commonjs",
+	    target: "es3",
+	    out: "docs/",
+	    name: "Together We Remember"
+        }));
+});
 
 gulp.task("styles", function () {
     var sassTask = sass({

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "build": "gulp",
     "build-dev": "gulp dev",
+    "docs": "gulp docs",
     "test": "mocha --opts config/mocha.opts && rm -rf test",
     "heroku-postbuild": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
   "homepage": "https://github.com/cbh66/remember",
   "devDependencies": {
     "chai": "^3.5.0",
+    "gulp-typedoc": "^2.0.1",
     "mocha": "^3.1.2",
     "sinon": "^1.17.6",
-    "ts-loader": "^1.0.0"
+    "ts-loader": "^1.0.0",
+    "typedoc": "^0.5.1"
   },
   "dependencies": {
     "@types/lodash": "^4.14.40",

--- a/src/js/Queue.ts
+++ b/src/js/Queue.ts
@@ -31,7 +31,7 @@ export default class Queue<T> {
         return (this.queue.length == 0);
     }
 
-    /* Enqueues the specified item. The parameter is:
+    /** Enqueues the specified item. The parameter is:
      *
      * item - the item to enqueue
      */
@@ -39,7 +39,7 @@ export default class Queue<T> {
         this.queue.push(item);
     }
 
-    /* Dequeues an item and returns it. If the queue is empty, the value
+    /** Dequeues an item and returns it. If the queue is empty, the value
      * 'undefined' is returned.
      */
     public dequeue(): T {
@@ -60,7 +60,7 @@ export default class Queue<T> {
         return item;
     }
 
-    /* Returns the item at the front of the queue (without dequeuing it). If
+    /** Returns the item at the front of the queue (without dequeuing it). If
      * the queue is empty then undefined is returned.
      */
     public peek(): T {


### PR DESCRIPTION
Tasks pull type information and comments into html pages, placed in a `docs/` directory.  Closes #32.